### PR TITLE
Add astrbot_plugin_dsh (DSH 桥)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -13251,5 +13251,21 @@
     "desc": "过滤消息段中的think",
     "repo": "https://github.com/zgojin/astrbot_plugin_thinkTags",
     "category": "utilities"
+  },
+  "astrbot_plugin_dsh": {
+    "display_name": "DSH 桥",
+    "short_desc": "把指定会话接给本机 DeepSeek Harness，写代码 / 跑工具",
+    "desc": "把群聊 / 私聊接到本机运行的 DeepSeek Harness（DSH）：由它在你的电脑上写代码、跑命令、读写文件，过程和结果实时回到聊天；文本、图片、文件双向传递，权限确认与提问可直接在聊天里回复，不接管 AstrBot 的日常聊天。需先在本机装好 DSH 并启用 dsh-astrbot-ingress 入站插件。",
+    "author": "CCYellowStar2",
+    "repo": "https://github.com/CCYellowStar2/astrbot_plugin_dsh",
+    "category": "ai_tools",
+    "tags": [
+      "dsh",
+      "deepseek-harness",
+      "coding-agent",
+      "编程代理",
+      "远程开发"
+    ],
+    "social_link": "https://github.com/CCYellowStar2"
   }
 }


### PR DESCRIPTION
## 新增插件：astrbot_plugin_dsh（DSH 桥）

把指定会话（群聊 / 私聊）接到**本机运行的 [DeepSeek Harness](https://github.com/CCYellowStar2/dsh-astrbot-ingress)**（DSH）：由 DSH 在你的电脑上写代码、跑命令、读写文件，过程和结果实时回到聊天。

- 不接管 AstrBot 的日常聊天：只有绑定过 DSH 会话的会话才会被转发
- 文本 / 图片 / 文件双向传递，入站附件自动落到本机工作目录
- 过程显示分档位（完整 / 每段时间一条简报 / 只留结果）
- 权限确认与 `ask_user_question` 提问可直接在聊天里回复（网页端仍可并行作答）
- 插件仓库：https://github.com/CCYellowStar2/astrbot_plugin_dsh （metadata.yaml 必填字段齐全，根目录有 main.py，无第三方依赖）

DSH 侧入站插件：https://github.com/CCYellowStar2/dsh-astrbot-ingress

---

Adds the DSH bridge plugin: forwards selected AstrBot conversations to a locally running DeepSeek Harness coding agent (writes code / runs commands on your own machine, streams progress and results back to chat). No third-party dependencies; metadata.yaml complete; entry appended at the end of plugins.json.

## Summary by Sourcery

New Features:
- Register the new astrbot_plugin_dsh (DSH bridge) plugin in the plugin catalog.